### PR TITLE
seat: fix hiding cursor on touchscreen-capable seats

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -116,9 +116,10 @@ update_capabilities(struct cg_seat *seat) {
 	if (!wl_list_empty(&seat->touch)) {
 		caps |= WL_SEAT_CAPABILITY_TOUCH;
 	}
-	wlr_seat_set_capabilities(seat->seat, caps);
 
-	/* Hide cursor if the seat doesn't have pointer capability. */
+	/* Hide cursor if the seat doesn't have pointer capability.
+	 * This must be called while the wlr_seat has the capability
+	 * otherwise it's a no-op. */
 	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
 		wlr_cursor_set_image(seat->cursor, NULL, 0, 0, 0, 0, 0, 0);
 	} else {
@@ -126,6 +127,8 @@ update_capabilities(struct cg_seat *seat) {
 						     DEFAULT_XCURSOR,
 						     seat->cursor);
 	}
+
+	wlr_seat_set_capabilities(seat->seat, caps);
 }
 
 static void


### PR DESCRIPTION
Fixes #83.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed

## Summary by Sourcery

Bug Fixes:
- Fix hiding cursor on touchscreen-capable seats by ensuring cursor visibility is updated after setting seat capabilities.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Adjust the order of function calls in `update_capabilities` to ensure that `wlr_seat_set_capabilities` is invoked before attempting to hide the cursor when a seat lacks pointer capability.

### Why are these changes being made?

The change ensures that the cursor hiding operation is effective by first setting the appropriate capabilities on the `wlr_seat`, as the cursor hiding function is a no-op if called before this capability is set. This resolves an issue where touchscreen-capable seats were not properly hiding the cursor.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->